### PR TITLE
items() for python3 and add support for keys without values

### DIFF
--- a/templates/login.conf.j2
+++ b/templates/login.conf.j2
@@ -1,8 +1,10 @@
 # {{ ansible_managed }}
 
-{% for name, item in freebsd_login_conf.iteritems() %}
-{{ name }}{% if 'aliases' in item %}{% for alias in item['aliases'] %}|{{ alias }}{% endfor %}{% endif %}{% if 'description' in item %}|{{ item['description'] }}{% endif %}:{% for key, value in item.iteritems() %}{% if key != 'aliases' and key != 'description' %}\
-	:{{ key|regex_replace (':','\\\\c') }}={{ value|regex_replace (':','\\\\c') }}:{% endif %}{% endfor %}
+{% for name, item in freebsd_login_conf.items() %}
+{{ name }}{% if 'aliases' in item %}{% for alias in item['aliases'] %}|{{ alias }}{% endfor %}{% endif %}{% if 'description' in item %}|{{ item['description'] }}{% endif %}:{% for key, value in item.items() %}{% if key != 'aliases' and key != 'description' and value != None %}\
+	:{{ key|regex_replace (':','\\\\c') }}={{ value|regex_replace (':','\\\\c') }}:{% endif %}{% if value == None %}\
+	:{{ key|regex_replace (':','\\\\c') }}:{% endif %}
+{% endfor %}
 
 
 {% endfor %}


### PR DESCRIPTION
Use items() instead of iteritems() so it's python3 compatible. It's slightly inefficient in python2, but given were dealing with small maps here it doesn't seem like a problem.

Also add support for keys without values (such as ignorenologin) rather than setting them to "True".